### PR TITLE
Use dependencyDashboard instead of masterIssue

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
         "renovate"
     ],
 
-    "masterIssue": true,
+    "dependencyDashboard": true,
 
     "schedule": [
         "before 1am on Saturday"


### PR DESCRIPTION
## Changes:

- Use `dependencyDashboard` instead of `masterIssue`

## Context

Fixes the issue raised at https://github.com/renovatebot/renovate/issues/8135.
The output of `npm-config-validator` should be good to go now. 😉 

## Documentation for change:

You can read more about the dependencyDashboard setting here: https://docs.renovatebot.com/configuration-options/#dependencydashboard