### PR TITLE
Add EXE006: Shebang is present but it hard-codes the path to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/flake8-executable)
 [![Build Status](https://ci.appveyor.com/api/projects/status/h6mucl894w6dx7d0?svg=true)](https://ci.appveyor.com/project/xuhdev/flake8-executable)
 
-Very often, developers mess up the executable permissions and shebangs of Python files. For example,
+It's possible to make [executable Python scripts][] by adding a _[shebang][]_ line to the top of the file, and setting the execute bit of its permissions.
+
+Very often, however, developers mess up the executable permissions and shebangs of Python files. For example,
 sometimes the executable permission was accidentally granted, sometimes it is forgotten.
 
 This is a [Flake8][] plugin that ensures the executable permissions and shebangs of Python files are
@@ -16,6 +18,7 @@ correctly set. Specifically, it checks the following errors:
 - EXE003: Shebang is present but does not contain "python".
 - EXE004: There is whitespace before shebang.
 - EXE005: There are blank or comment lines before shebang.
+- EXE006: Shebang is present but it hard-codes the path to python.
 
 ## Installation
 
@@ -57,5 +60,7 @@ flake8-executable. If not, see <https://www.gnu.org/licenses/>.
 
 
 
+[Executable Python scripts]: https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts
+[Shebang]: https://en.wikipedia.org/wiki/Shebang_(Unix)
 [Flake8]: https://flake8.pycqa.org/
 [Flake8 plugin page]: https://flake8.pycqa.org/en/latest/user/using-plugins.html

--- a/tests/test_flake8_executable.py
+++ b/tests/test_flake8_executable.py
@@ -21,7 +21,7 @@ import sys
 
 import pytest
 
-from flake8_executable import ExecutableChecker, EXE001, EXE002, EXE003, EXE004, EXE005
+from flake8_executable import ExecutableChecker, EXE001, EXE002, EXE003, EXE004, EXE005, EXE006
 
 WIN32 = sys.platform.startswith("win")
 
@@ -47,7 +47,8 @@ class TestFlake8Executable:
         pytest.param(EXE002(), 'exe002', marks=pytest.mark.skipif(WIN32, reason="Windows doesn't support EXE002")),
         (EXE003(line_number=1, shebang='#!/bin/bash'), 'exe003'),
         (EXE004(line_number=1, offset=4), 'exe004'),
-        (EXE005(line_number=3), 'exe005')])
+        (EXE005(line_number=3), 'exe005'),
+        (EXE006(line_number=1, shebang='#!/usr/bin/python'), 'exe006')])
     def test_exe_positive(self, error, error_code):
         "Test cases in which an error should be reported."
         filename = __class__._get_pos_filename(error_code)
@@ -71,7 +72,8 @@ class TestFlake8Executable:
         'exe002',
         'exe003',
         'exe004',
-        'exe005'])
+        'exe005',
+        'exe006'])
     def test_exe_negative(self, error_code):
         "Test cases in which no error should be reported."
         filename = __class__._get_neg_filename(error_code)
@@ -89,7 +91,8 @@ class TestFlake8Executable:
     @pytest.mark.parametrize("error, error_code", [
         (EXE003(line_number=1, shebang='#!/bin/bash'), 'exe003'),
         (EXE004(line_number=1, offset=4), 'exe004'),
-        (EXE005(line_number=3), 'exe005')])
+        (EXE005(line_number=3), 'exe005'),
+        (EXE006(line_number=1, shebang='#!/usr/bin/python'), 'exe006')])
     def test_stdin_positive(self, error, error_code):
         "Test case in which an error should be reported (input is stdin)."
         filename = __class__._get_pos_filename(error_code)

--- a/tests/to-be-tested/exe001_neg.py
+++ b/tests/to-be-tested/exe001_neg.py
@@ -1,2 +1,2 @@
 if __name__ == '__main__':
-    print('I should be executable.')
+    print('I do not have a shebang and am therefore not executable.')

--- a/tests/to-be-tested/exe001_pos.py
+++ b/tests/to-be-tested/exe001_pos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 if __name__ == '__main__':
-    print('I should be executable.')
+    print('I should be executable because I have a shebang.')

--- a/tests/to-be-tested/exe003_neg.py
+++ b/tests/to-be-tested/exe003_neg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 if __name__ == '__main__':
-    print('Wrong shebang.')
+    print('Correct shebang.')

--- a/tests/to-be-tested/exe004_neg.py
+++ b/tests/to-be-tested/exe004_neg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 if __name__ == '__main__':
     print('I do not have whitespace before shebang.')

--- a/tests/to-be-tested/exe004_pos.py
+++ b/tests/to-be-tested/exe004_pos.py
@@ -1,4 +1,4 @@
-    #!/usr/bin/python3
+    #!/usr/bin/env python3
 
 if __name__ == '__main__':
     print('I have whitespace before shebang.')

--- a/tests/to-be-tested/exe005_neg.py
+++ b/tests/to-be-tested/exe005_neg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 if __name__ == '__main__':
     print('I do not have any blank or comment lines before shebang.')

--- a/tests/to-be-tested/exe005_pos.py
+++ b/tests/to-be-tested/exe005_pos.py
@@ -1,6 +1,6 @@
 
 #
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 if __name__ == '__main__':
     print('I have blank and comment lines before shebang.')

--- a/tests/to-be-tested/exe006_neg.py
+++ b/tests/to-be-tested/exe006_neg.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+if __name__ == '__main__':
+    print('I use /usr/bin/env to find the python interpreter.')

--- a/tests/to-be-tested/exe006_pos.py
+++ b/tests/to-be-tested/exe006_pos.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python
+
+if __name__ == '__main__':
+    print('I have hard-coded the python interpreter path.')


### PR DESCRIPTION
Hello @xuhdev, I hope you appreciate this contribution.

The Python tutorial suggests using `#!/usr/bin/env python` for shebangs.

This way is better than plain `#!/usr/bin/python` because it allows the user running the script to control which Python executable to interpret the script with.

This is especially true when working with virtualenvs, custom install prefixes, and the like.

This PR adds _EXE006: Shebang is present but it hard-codes the path to python_. The unit tests are modified and extended accordingly.
